### PR TITLE
ci: automate Play internal-track releases from GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+# Publishing a GitHub Release (with a vMAJOR.MINOR.PATCH tag) builds a signed
+# App Bundle and uploads it to Google Play's internal testing track.
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  release:
+    name: Build & publish to Play (internal)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve version name from tag
+        id: version
+        run: echo "name=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'jetbrains'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode upload keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/upload.jks"
+
+      - name: Build release bundle
+        env:
+          VERSION_NAME: ${{ steps.version.outputs.name }}
+          KEYSTORE_FILE: ${{ runner.temp }}/upload.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew bundleRelease
+
+      - name: Upload to Google Play (internal)
+        uses: r0adkll/upload-google-play@v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          packageName: dev.yuyuyuyuyu.barometer
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,23 @@ plugins {
     id("kotlin-parcelize")
 }
 
+// Release metadata injected by CI (see .github/workflows/release.yml).
+// All are null for local builds, which then fall back to debug signing and the
+// hardcoded version below.
+val releaseVersionName: String? = System.getenv("VERSION_NAME")
+val releaseKeystoreFile: String? = System.getenv("KEYSTORE_FILE")
+
+// Maps a semantic version name to a strictly increasing Int versionCode.
+// minor and patch each occupy 3 digits (0..999); major can go up to 2099
+// before exceeding Google Play's 2,100,000,000 limit.
+fun versionNameToCode(name: String): Int {
+    val parts = name.split(".")
+    require(parts.size == 3) { "VERSION_NAME must be MAJOR.MINOR.PATCH, but was: $name" }
+    val (major, minor, patch) = parts.map(String::toInt)
+    require(minor in 0..999 && patch in 0..999) { "minor/patch must be 0..999, but was: $name" }
+    return major * 1_000_000 + minor * 1_000 + patch
+}
+
 android {
     namespace = "dev.yuyuyuyuyu.barometer"
     compileSdk = 36
@@ -17,10 +34,21 @@ android {
         applicationId = "dev.yuyuyuyuyu.barometer"
         minSdk = 24
         targetSdk = 35
-        versionCode = 3
-        versionName = "0.5.0"
+        versionCode = releaseVersionName?.let(::versionNameToCode) ?: 3
+        versionName = releaseVersionName ?: "0.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        if (releaseKeystoreFile != null) {
+            create("release") {
+                storeFile = file(releaseKeystoreFile)
+                storePassword = System.getenv("KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
@@ -30,7 +58,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName(
+                if (releaseKeystoreFile != null) "release" else "debug"
+            )
         }
     }
     compileOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "dev.yuyuyuyuyu.barometer"
         minSdk = 24
         targetSdk = 35
-        versionCode = releaseVersionName?.let(::versionNameToCode) ?: 3
-        versionName = releaseVersionName ?: "0.5.0"
+        versionCode = releaseVersionName?.let(::versionNameToCode) ?: 1
+        versionName = releaseVersionName ?: "0.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
Publishing a GitHub Release now builds a signed App Bundle and uploads it to the Google Play **internal testing track** automatically. This removes the manual release steps and keeps the developer account active with no ongoing effort.

## Changes
- **`.github/workflows/release.yml`** (new): triggered on `release: published`. Restores the upload keystore from secrets, runs `bundleRelease`, and uploads to the internal track via `r0adkll/upload-google-play@v1.1.5`.
- **`app/build.gradle.kts`**:
  - Release builds are signed with the upload key supplied through CI environment variables, falling back to debug signing for local builds (when no env is present).
  - `versionName` is derived from the release tag and `versionCode` from `major*1,000,000 + minor*1,000 + patch` (minor/patch each `0..999`), so neither needs to be bumped by hand.

## Required GitHub secrets (already configured)
`KEYSTORE_BASE64` / `KEYSTORE_PASSWORD` / `KEY_ALIAS` / `KEY_PASSWORD` / `SERVICE_ACCOUNT_JSON`

## Release flow (after merge)
1. Merge this PR into `main` (the workflow must live on the default branch to be triggered by releases).
2. Create and publish a GitHub Release with a `vX.Y.Z` tag (e.g. `v0.5.1`).
3. The workflow builds the bundle and ships it to the internal testing track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)