### PR TITLE
ci: migrate deprecated `track` input to `tracks`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: dev.yuyuyuyuyu.barometer
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: internal
+          tracks: internal
           status: completed


### PR DESCRIPTION
## Summary
The v0.5.1 release run logged this warning from `r0adkll/upload-google-play`:

> WARNING!! 'track' is deprecated and will be removed in a future release. Please migrate to 'tracks'

This renames the input accordingly (`track: internal` → `tracks: internal`). No behavior change — the internal testing track remains the upload target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)